### PR TITLE
comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ $ run_docker_ci_job # optional (--prune)
 
 ## Langugage Spec(ish)
 
+### Comments
+
+YAIWR comments can be used to explain the YAIWR code. 
+YAIWR comments can be used to prevent execution when testing alternative code.
+
+Convention:
+
+1. Single-line comments should start with `//`
+2. No multi-line comment supported
+
+Example:
+
+```
+let _a = 4; // let _a = 5;
+// let _a = 5;
+println(_a);
+```
+In this example, the output will be `4`.
+
 ### Statements
 
 `println` - Prints to the standard output, with a new line
@@ -171,6 +190,8 @@ fun f() {
 
 [x] Multi-line statements support as it was intended in https://github.com/softdevteam/pavel.yaiwr/pull/17
 
+[x] Add comments support
+
 [ ] Allow function calls without `;`, for example: `add1(add1(1))` instead of `add1(add1(1););`
 
 [ ] Compile variable names to integers
@@ -182,6 +203,8 @@ fun f() {
 [ ] Benchmarking
 
 [ ] Revise Rust in general :)
+
+[ ] Add multi-line comments support. See previous PR attempt: https://github.com/softdevteam/pavel.yaiwr/pull/22.
 
 # Terminology
 

--- a/programs/tests/comments_expect_output_4.yaiwr
+++ b/programs/tests/comments_expect_output_4.yaiwr
@@ -1,0 +1,3 @@
+let __zzzzzzz = 4;   // let __zzzzzzz = 100;
+// Should be ignored!
+println(__zzzzzzz);

--- a/programs/tests/functions_call_from_function_call.yaiwr
+++ b/programs/tests/functions_call_from_function_call.yaiwr
@@ -1,5 +1,5 @@
 let _x = 2;
 let _y = 3;
-fun _add (_arg1, _arg2){ return _id(_arg1) + _id(_arg2); }
-fun _id (_arg1){ return _arg1; }
-println(_add(_x, _y));
+fun add (_arg1, _arg2){ return id(_arg1); + id(_arg2); }
+fun id (_arg1){ return _arg1; }
+println(add(_x, _y););

--- a/src/calc.l
+++ b/src/calc.l
@@ -16,4 +16,5 @@ return "RETURN"
 _[a-zA-Z0-9_]+ "T_VARIABLE"
 [a-zA-Z0-9_]+ "T_FUNCTION" 
 [\t\n ]+ ;
+//[^\n]*?$ ;
 . "UNMATCHED"

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -1,0 +1,47 @@
+mod print;
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use yaiwr::{scope::Scope, Calc};
+
+    #[test]
+    fn comment_no_evaluation_bc() {
+        let calc = &mut Calc::new();
+        let scope = &mut Scope::new();
+        let ast = calc.from_str("// let _a = 5;\n").unwrap();
+        let bytecode = Calc::ast_to_bytecode(ast);
+        assert_eq!(calc.eval(&bytecode, scope).unwrap(), None);
+        assert_eq!(bytecode.len(), 0);
+    }
+
+    #[test]
+    fn comment_multiline() {
+        let calc = &mut Calc::new();
+        let scope = &mut Scope::new();
+        let ast = calc
+            .from_str(
+                "
+        let _a = 4; // Should be ignored!
+        // Should be ignored!
+        _a+1
+        ",
+            )
+            .unwrap();
+        let bytecode = Calc::ast_to_bytecode(ast);
+        assert_eq!(calc.eval(&bytecode, scope).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn comment_expected_output_4() {
+        let file_path = "./programs/tests/comments_expect_output_4.yaiwr";
+        let output = Command::new("cargo")
+            .arg("run")
+            .arg(file_path)
+            .output()
+            .expect(format!("comand 'cargo run {}' failed", file_path).as_str());
+
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "4",);
+    }
+}


### PR DESCRIPTION
Comments:
    + single line
    + multiline

### Comments

YAIWR comments can be used to explain the YAIWR code. 
YAIWR comments can be used to prevent execution when testing alternative code.

Convention:

1. Single line comments should start with `//`
2. Multi-line comments should start with `/*` and end with `*/`

Example:

```
let _a = 4; // let _a = 5;
// let _a = 5;
/* 
  multi-line comment here
*/
println(_a);
```
In this example, the output will be `4`.
